### PR TITLE
for prettified output, end with a new line

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 
 var isJSON = require('koa-is-json');
 var Stringify = require('streaming-json-stringify');
+var os = require('os')
 
 /**
  * Pretty JSON response middleware.
@@ -46,7 +47,7 @@ module.exports = function(opts){
 
     // prettify JSON responses
     if (json && prettify) {
-      return this.body = JSON.stringify(body, null, spaces);
+      return this.body = JSON.stringify(body, null, spaces) + os.EOL;
     }
   }
 };


### PR DESCRIPTION
when developing a new REST endpoint i typically enable prettify (using this module) and test it from the terminal, using curl.. the new line i've added avoids that awkward situation where your next bash prompt begins at the end of the output and is offset by one character (you need to hit return to fix it), 

i.e. this:

```
lloyd:$ curl <koa app>
{
  "status": "wonderful",
  "output": "yes it is"
}lloyd:$
```

is now this: 
```
lloyd:$ curl <koa app>
{
  "status": "wonderful",
  "output": "yes it is"
}
lloyd:$
```