### PR TITLE
Compatibility with Node 6.0.0.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(opts){
     if (!json && !stream) return;
 
     // query
-    var hasParam = param && this.query.hasOwnProperty(param);
+    var hasParam = param && (this.query[param] != null);
     var prettify = pretty || hasParam;
 
     // always stringify object streams


### PR DESCRIPTION
Reason: https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring

# Test Runs:
## Before (6.0.0):
```bash
[10:38:12] | nico | json @(master):  node --version
v6.0.0
[10:38:26] | nico | json @(master):  npm test

> koa-json@1.1.1 test /Users/nico/Workspace/Server/json
> NODE_ENV=test mocha --reporter spec



  param
    ✓ should default to being disabled
    1) should pretty-print when present

  pretty
    ✓ should default to true
    ✓ should retain content-type
    ✓ should pass through when false
    ✓ should allow custom spaces

  streams
    ✓ should not do anything binary streams
    ✓ should always stringify object streams
    ✓ should prettify object streams


  8 passing (74ms)
  1 failing

  1) param should pretty-print when present:
     Error: expected '{\n  "foo": "bar"\n}' response body, got 'Internal Server Error'
      at error (node_modules/supertest/lib/test.js:265:13)
      at Test._assertBody (node_modules/supertest/lib/test.js:191:16)
      at Test._assertFunction (node_modules/supertest/lib/test.js:247:11)
      at Test.assert (node_modules/supertest/lib/test.js:148:18)
      at assert (node_modules/supertest/lib/test.js:127:12)
      at node_modules/supertest/lib/test.js:124:5
      at Test.Request.callback (node_modules/superagent/lib/node/index.js:703:3)
      at IncomingMessage.<anonymous> (node_modules/superagent/lib/node/index.js:922:12)
      at endReadableNT (_stream_readable.js:926:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)



npm ERR! Test failed.  See above for more details.
```

## After (6.0.0):
```bash
[10:42:38] | nico | json @(patch/node-6.0.0-compatibility):  node --version
v6.0.0
[10:42:40] | nico | json @(patch/node-6.0.0-compatibility):  npm test

> koa-json@1.1.1 test /Users/nico/Workspace/Server/json
> NODE_ENV=test mocha --reporter spec



  param
    ✓ should default to being disabled
    ✓ should pretty-print when present

  pretty
    ✓ should default to true
    ✓ should retain content-type
    ✓ should pass through when false
    ✓ should allow custom spaces

  streams
    ✓ should not do anything binary streams
    ✓ should always stringify object streams
    ✓ should prettify object streams


  9 passing (66ms)
```

## After (5.4.1):
```bash
[10:43:09] | nico | json @(patch/node-6.0.0-compatibility):  node --version
v5.4.1
[10:43:11] | nico | json @(patch/node-6.0.0-compatibility):  npm test

> koa-json@1.1.1 test /Users/nico/Workspace/Server/json
> NODE_ENV=test mocha --reporter spec



  param
    ✓ should default to being disabled
    ✓ should pretty-print when present

  pretty
    ✓ should default to true
    ✓ should retain content-type
    ✓ should pass through when false
    ✓ should allow custom spaces

  streams
    ✓ should not do anything binary streams
    ✓ should always stringify object streams
    ✓ should prettify object streams


  9 passing (68ms)

[10:43:15] | nico | json @(patch/node-6.0.0-compatibility):
```