### PR TITLE
Updated jsdocs to be more descriptive

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,2 +1,1 @@
----
 extends: standard

--- a/index.js
+++ b/index.js
@@ -4,21 +4,29 @@ const isJSON = require('koa-is-json')
 
 const hasOwnProperty = Object.hasOwnProperty
 
+const defaultOptions = {
+  pretty: true,
+  spaces: 2
+}
+
+/** @typedef {import("koa").Middleware} Middleware */
+
 /**
  * Pretty JSON response middleware.
- *
- *  - `pretty` default to pretty response [true]
- *  - `param` optional query-string param for pretty responses [none]
- *
- * @param {Object} opts
- * @return {GeneratorFunction}
+ * @param {Object} options
+ * @param {boolean=} options.pretty
+ *   Whether to format the json with newlines and spaces. Default `true`
+ * @param {number=} options.spaces number of spaces to use as tab
+ * @param {string=} options.param
+ *   query-string param that will bypass pretty config if present
+ * @return {Middleware}
  * @api public
  */
 
-module.exports = function (opts = {}) {
-  const param = opts.param
-  const pretty = opts.pretty == null ? true : opts.pretty
-  const spaces = opts.spaces || 2
+module.exports = function (options = defaultOptions) {
+  const pretty = options.pretty == null ? true : options.pretty
+  const spaces = options.spaces || 2
+  const param = options.param
 
   return function filter (ctx, next) {
     return next().then(() => {

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,3 +1,2 @@
----
 env:
   mocha: true

--- a/test/param.js
+++ b/test/param.js
@@ -14,8 +14,8 @@ describe('param', () => {
     })
 
     request(app.listen())
-    .get('/?pretty')
-    .expect('{"foo":"bar"}', done)
+      .get('/?pretty')
+      .expect('{"foo":"bar"}', done)
   })
 
   it('should pretty-print when present', (done) => {
@@ -28,7 +28,7 @@ describe('param', () => {
     })
 
     request(app.listen())
-    .get('/?pretty')
-    .expect('{\n  "foo": "bar"\n}', done)
+      .get('/?pretty')
+      .expect('{\n  "foo": "bar"\n}', done)
   })
 })

--- a/test/pretty.js
+++ b/test/pretty.js
@@ -14,8 +14,8 @@ describe('pretty', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('{\n  "foo": "bar"\n}', done)
+      .get('/')
+      .expect('{\n  "foo": "bar"\n}', done)
   })
 
   it('should ok', (done) => {
@@ -28,8 +28,8 @@ describe('pretty', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('{\n  "foo": null\n}', done)
+      .get('/')
+      .expect('{\n  "foo": null\n}', done)
   })
 
   it('should retain content-type', (done) => {
@@ -42,8 +42,8 @@ describe('pretty', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('Content-Type', /application\/json/, done)
+      .get('/')
+      .expect('Content-Type', /application\/json/, done)
   })
 
   it('should pass through when false', (done) => {
@@ -56,8 +56,8 @@ describe('pretty', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('{"foo":"bar"}', done)
+      .get('/')
+      .expect('{"foo":"bar"}', done)
   })
 
   it('should allow custom spaces', (done) => {
@@ -73,7 +73,7 @@ describe('pretty', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('{\n    "foo": "bar"\n}', done)
+      .get('/')
+      .expect('{\n    "foo": "bar"\n}', done)
   })
 })

--- a/test/streams.js
+++ b/test/streams.js
@@ -18,13 +18,13 @@ describe('streams', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect(200, (err, res) => {
-      if (err) return done(err)
+      .get('/')
+      .expect(200, (err, res) => {
+        if (err) return done(err)
 
-      assert.equal(res.body.toString(), 'lol')
-      done()
-    })
+        assert.equal(res.body.toString(), 'lol')
+        done()
+      })
   })
 
   it('should always stringify object streams', (done) => {
@@ -46,20 +46,20 @@ describe('streams', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('Content-Type', /application\/json/)
-    .expect(200, (err, res) => {
-      if (err) return done(err)
+      .get('/')
+      .expect('Content-Type', /application\/json/)
+      .expect(200, (err, res) => {
+        if (err) return done(err)
 
-      assert.ok(res.text.includes('{"message":"1"}'))
-      assert.ok(res.text.includes('{"message":"2"}'))
-      assert.deepEqual(res.body, [{
-        message: '1'
-      }, {
-        message: '2'
-      }])
-      done()
-    })
+        assert.ok(res.text.includes('{"message":"1"}'))
+        assert.ok(res.text.includes('{"message":"2"}'))
+        assert.deepEqual(res.body, [{
+          message: '1'
+        }, {
+          message: '2'
+        }])
+        done()
+      })
   })
 
   it('should prettify object streams', (done) => {
@@ -79,19 +79,19 @@ describe('streams', () => {
     })
 
     request(app.listen())
-    .get('/')
-    .expect('Content-Type', /application\/json/)
-    .expect(200, (err, res) => {
-      if (err) return done(err)
+      .get('/')
+      .expect('Content-Type', /application\/json/)
+      .expect(200, (err, res) => {
+        if (err) return done(err)
 
-      assert.ok(res.text.includes('{\n  "message": "1"\n}'))
-      assert.ok(res.text.includes('{\n  "message": "2"\n}'))
-      assert.deepEqual(res.body, [{
-        message: '1'
-      }, {
-        message: '2'
-      }])
-      done()
-    })
+        assert.ok(res.text.includes('{\n  "message": "1"\n}'))
+        assert.ok(res.text.includes('{\n  "message": "2"\n}'))
+        assert.deepEqual(res.body, [{
+          message: '1'
+        }, {
+          message: '2'
+        }])
+        done()
+      })
   })
 })


### PR DESCRIPTION
The current jsdocs aren't descriptive enough for typescript to understand that this middleware is compatible with Koa.
I've updated them to specify this returns a Koa.Middleware and to better describe the options object.
In addition I added a default parameter to indicate that options is optional.

When I ran lint, there were some other files that ended up being modified, which I included.
I also renamed the eslint config files to reflect that they are using yaml.